### PR TITLE
fix: surface Bazarr's error messages instead of showing no results (#9)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,6 +29,12 @@ git tag -a v1.1.5 -m "Description of changes" && git push origin v1.1.5
 - `manifest.json` - Jellyfin plugin manifest (auto-updated by release workflow)
 - `.github/workflows/release.yaml` - Release automation
 
+## Commits and Pull Requests
+
+- **No AI attribution.** Never add `Co-Authored-By: Claude`, "Generated with Claude Code",
+  or any similar trailer, footer or badge to a commit message, PR title, PR body or issue
+  comment. Commits are authored by the repository owner.
+
 ## API Notes
 
 - Bazarr API uses array notation for some parameters (e.g., `seriesid[]` not `seriesid`)
@@ -78,7 +84,26 @@ The episode lookup process uses fallback logic due to an ID mismatch between Jel
 
 **Bazarr API structure:**
 - `/api/series` returns `tvdbId`, `imdbId`, `sonarrSeriesId` (series-level only)
-- `/api/episodes?seriesid[]={sonarrSeriesId}` returns `sonarrEpisodeId`, `season`, `episode` (NO tvdbId)
+- `/api/episodes?seriesid[]={sonarrSeriesId}` returns `sonarrEpisodeId`, `sonarrSeriesId`, `season`, `episode` (NO tvdbId)
 - `/api/providers/episodes?episodeid={sonarrEpisodeId}` searches for subtitles
 
+### Movies Match on IMDB Only (BY DESIGN)
 
+Bazarr's `/api/movies` marshals a model that has **no `tmdbId` field** - see `movies_data_model`
+in `bazarr/api/movies/movies.py`; `flask_restx.marshal` drops anything not declared there.
+Matching a Jellyfin movie to Bazarr therefore only works through `imdbId`, in the search
+handler, the controller and the post-download library refresh.
+
+**DO NOT re-add TMDB matching** - it silently never matches, which is what made the
+post-download refresh a no-op for every movie.
+
+### Status Rows in Search Results (BY DESIGN)
+
+Jellyfin's `SubtitleManager.SearchSubtitles` catches every exception a provider throws and
+returns an empty list, so a failed search is indistinguishable from "no subtitles found".
+
+When a search cannot return results, the plugin therefore returns a single non-downloadable
+row built by `SubtitlePlaceholder` (id prefixed `placeholder_`) carrying the reason in
+`Comment`. `GetSubtitles` rejects those ids. `ValidateResponseAsync` feeds it Bazarr's own
+error text - Bazarr answers failures with a JSON-encoded string body such as
+`"All providers are throttled"` (see `bazarr/api/providers/providers_movies.py`).

--- a/Jellyfin.Plugin.Bazarr.Tests/BazarrServiceCachingTests.cs
+++ b/Jellyfin.Plugin.Bazarr.Tests/BazarrServiceCachingTests.cs
@@ -49,7 +49,7 @@ public class BazarrServiceCachingTests : IDisposable
     public async Task GetMoviesAsync_SecondCall_UsesCacheNotHttp()
     {
         // Arrange - Only one response queued
-        var moviesJson = """{ "data": [{ "radarrId": 1, "title": "Test", "tmdbId": 123 }] }""";
+        var moviesJson = """{ "data": [{ "radarrId": 1, "title": "Test", "imdbId": "tt0000001" }] }""";
         _mockHandler.QueueResponse(HttpStatusCode.OK, moviesJson);
 
         // Act - Call twice
@@ -123,5 +123,27 @@ public class BazarrServiceCachingTests : IDisposable
         Assert.Equal(2, _mockHandler.CapturedRequests.Count);
         Assert.Equal(1, result1[0].SonarrEpisodeId);
         Assert.Equal(100, result2[0].SonarrEpisodeId);
+    }
+
+    /// <summary>
+    /// CRITICAL: A caller joining an in-flight search must still honour its timeout, and must
+    /// not start a second Bazarr search. Without this, the second viewer's request hangs until
+    /// Bazarr finishes - up to the 20 minute HttpClient timeout.
+    /// </summary>
+    [Fact]
+    public async Task SearchMovieSubtitlesAsync_JoiningInFlightSearch_HonoursTimeoutAndReusesSearch()
+    {
+        // Arrange - a Bazarr search far slower than the caller's timeout
+        _mockHandler.ResponseDelay = TimeSpan.FromSeconds(5);
+        _mockHandler.QueueResponse(HttpStatusCode.OK, """{ "data": [] }""");
+
+        // Act - two concurrent searches for the same movie, both with a 1s timeout
+        var results = await Task.WhenAll(
+            _service.SearchMovieSubtitlesAsync(1, "en", 1),
+            _service.SearchMovieSubtitlesAsync(1, "en", 1));
+
+        // Assert - both returned early, and only one search hit Bazarr
+        Assert.All(results, r => Assert.True(r.SearchInProgress));
+        Assert.Single(_mockHandler.CapturedRequests);
     }
 }

--- a/Jellyfin.Plugin.Bazarr.Tests/BazarrServiceErrorHandlingTests.cs
+++ b/Jellyfin.Plugin.Bazarr.Tests/BazarrServiceErrorHandlingTests.cs
@@ -115,6 +115,24 @@ public class BazarrServiceErrorHandlingTests : IDisposable
     }
 
     /// <summary>
+    /// Bazarr answers a throttled manual search with 500 and a JSON-encoded string body.
+    /// That message must reach the caller instead of a bare status code (issue #9).
+    /// </summary>
+    [Fact]
+    public async Task SearchMovieSubtitlesAsync_WhenProvidersThrottled_ThrowsWithBazarrMessage()
+    {
+        // Arrange
+        _mockHandler.QueueResponse(HttpStatusCode.InternalServerError, "\"All providers are throttled\"\n");
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<HttpRequestException>(
+            () => _service.SearchMovieSubtitlesAsync(1, "en"));
+
+        Assert.Equal(HttpStatusCode.InternalServerError, exception.StatusCode);
+        Assert.Contains("All providers are throttled", exception.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// When Bazarr returns empty data array, should return empty list not crash.
     /// </summary>
     [Fact]

--- a/Jellyfin.Plugin.Bazarr.Tests/BazarrServiceIdLookupTests.cs
+++ b/Jellyfin.Plugin.Bazarr.Tests/BazarrServiceIdLookupTests.cs
@@ -41,82 +41,10 @@ public class BazarrServiceIdLookupTests : IDisposable
         GC.SuppressFinalize(this);
     }
 
-    #region FindRadarrIdByTmdbAsync Tests
-
-    /// <summary>
-    /// CRITICAL: Verify we find the correct movie by TMDB ID.
-    /// If this fails, subtitles could be downloaded for the wrong movie.
-    /// </summary>
-    [Fact]
-    public async Task FindRadarrIdByTmdbAsync_WhenMovieExists_ReturnsCorrectRadarrId()
-    {
-        // Arrange - Bazarr returns 3 movies, we want movie with TMDB ID 550 (Fight Club)
-        var moviesJson = """
-        {
-            "data": [
-                { "radarrId": 1, "title": "The Matrix", "tmdbId": 603 },
-                { "radarrId": 2, "title": "Fight Club", "tmdbId": 550 },
-                { "radarrId": 3, "title": "Inception", "tmdbId": 27205 }
-            ]
-        }
-        """;
-        _mockHandler.QueueResponse(HttpStatusCode.OK, moviesJson);
-
-        // Act
-        var result = await _service.FindRadarrIdByTmdbAsync(550);
-
-        // Assert - Must return radarrId 2 for Fight Club, not any other movie
-        Assert.Equal(2, result);
-    }
-
-    /// <summary>
-    /// Verify we don't accidentally return a movie when TMDB ID doesn't match.
-    /// A bug here could cause subtitles for a random movie.
-    /// </summary>
-    [Fact]
-    public async Task FindRadarrIdByTmdbAsync_WhenMovieDoesNotExist_ReturnsNull()
-    {
-        // Arrange - Bazarr has movies, but not the one we're looking for
-        var moviesJson = """
-        {
-            "data": [
-                { "radarrId": 1, "title": "The Matrix", "tmdbId": 603 },
-                { "radarrId": 2, "title": "Inception", "tmdbId": 27205 }
-            ]
-        }
-        """;
-        _mockHandler.QueueResponse(HttpStatusCode.OK, moviesJson);
-
-        // Act - Look for TMDB ID 550 which doesn't exist
-        var result = await _service.FindRadarrIdByTmdbAsync(550);
-
-        // Assert - Must be null, not some other movie
-        Assert.Null(result);
-    }
-
-    /// <summary>
-    /// Edge case: What if Bazarr has no movies at all?
-    /// </summary>
-    [Fact]
-    public async Task FindRadarrIdByTmdbAsync_WhenNoMoviesExist_ReturnsNull()
-    {
-        // Arrange - Empty list from Bazarr
-        var moviesJson = """{ "data": [] }""";
-        _mockHandler.QueueResponse(HttpStatusCode.OK, moviesJson);
-
-        // Act
-        var result = await _service.FindRadarrIdByTmdbAsync(550);
-
-        // Assert
-        Assert.Null(result);
-    }
-
-    #endregion
-
     #region FindRadarrIdByImdbAsync Tests
 
     /// <summary>
-    /// CRITICAL: IMDB lookup is the fallback when TMDB fails.
+    /// CRITICAL: IMDB is the only movie key Bazarr exposes.
     /// Verify case-insensitive matching (IMDB IDs could be "tt0137523" or "TT0137523").
     /// </summary>
     [Fact]

--- a/Jellyfin.Plugin.Bazarr.Tests/BazarrServiceResponseValidationTests.cs
+++ b/Jellyfin.Plugin.Bazarr.Tests/BazarrServiceResponseValidationTests.cs
@@ -192,7 +192,7 @@ public class BazarrServiceResponseValidationTests
         // Arrange
         var jsonContent = @"{
             ""data"": [
-                {""title"": ""Test Movie"", ""radarrId"": 1, ""tmdbId"": 12345}
+                {""title"": ""Test Movie"", ""radarrId"": 1, ""imdbId"": ""tt0000001""}
             ]
         }";
 

--- a/Jellyfin.Plugin.Bazarr.Tests/Helpers/MockHttpMessageHandler.cs
+++ b/Jellyfin.Plugin.Bazarr.Tests/Helpers/MockHttpMessageHandler.cs
@@ -23,6 +23,11 @@ public class MockHttpMessageHandler : HttpMessageHandler
     public HttpRequestMessage? LastRequest => _requests.Count > 0 ? _requests[^1] : null;
 
     /// <summary>
+    /// Optional delay before each response, to simulate Bazarr's slow provider searches.
+    /// </summary>
+    public TimeSpan ResponseDelay { get; set; }
+
+    /// <summary>
     /// Adds a response for a specific endpoint path.
     /// </summary>
     public void AddResponse(string path, HttpStatusCode statusCode, string content, string contentType = "application/json")
@@ -58,12 +63,18 @@ public class MockHttpMessageHandler : HttpMessageHandler
         _responses.Enqueue(new ExceptionResponse(exception));
     }
 
+
     /// <inheritdoc />
-    protected override Task<HttpResponseMessage> SendAsync(
+    protected override async Task<HttpResponseMessage> SendAsync(
         HttpRequestMessage request,
         CancellationToken cancellationToken)
     {
         _requests.Add(request);
+
+        if (ResponseDelay > TimeSpan.Zero)
+        {
+            await Task.Delay(ResponseDelay, cancellationToken);
+        }
 
         // Check if we have a response for this specific endpoint
         var path = request.RequestUri?.PathAndQuery ?? string.Empty;
@@ -87,7 +98,7 @@ public class MockHttpMessageHandler : HttpMessageHandler
                 response.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse(contentTypeValue);
             }
 
-            return Task.FromResult(response);
+            return response;
         }
 
         // Fall back to queued responses
@@ -104,7 +115,7 @@ public class MockHttpMessageHandler : HttpMessageHandler
             throw exResponse.Exception;
         }
 
-        return Task.FromResult(queuedResponse);
+        return queuedResponse;
     }
 
     private class ExceptionResponse : HttpResponseMessage

--- a/Jellyfin.Plugin.Bazarr/Api/BazarrController.cs
+++ b/Jellyfin.Plugin.Bazarr/Api/BazarrController.cs
@@ -50,7 +50,7 @@ public class BazarrController : ControllerBase
     /// <param name="language">The language code (default: en).</param>
     /// <response code="200">Subtitles found.</response>
     /// <response code="404">Item not found or not in Bazarr.</response>
-    /// <returns>List of available subtitles.</returns>
+    /// <returns>A <see cref="SubtitleSearchResult"/> for both movies and episodes.</returns>
     [HttpGet("Search/{itemId}")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -74,8 +74,7 @@ public class BazarrController : ControllerBase
             }
 
             _logger.LogInformation("Searching subtitles for movie {Title} (radarrId: {RadarrId})", movie.Name, radarrId);
-            var subtitles = await _bazarrService.SearchMovieSubtitlesAsync(radarrId.Value, language).ConfigureAwait(false);
-            return Ok(subtitles);
+            return Ok(await _bazarrService.SearchMovieSubtitlesAsync(radarrId.Value, language).ConfigureAwait(false));
         }
 
         // Handle Episode
@@ -105,8 +104,7 @@ public class BazarrController : ControllerBase
                 return NotFound("Could not find series for episode");
             }
 
-            var subtitles = await _bazarrService.SearchEpisodeSubtitlesAsync(sonarrEpisodeId.Value, seriesId, language).ConfigureAwait(false);
-            return Ok(subtitles.Subtitles);
+            return Ok(await _bazarrService.SearchEpisodeSubtitlesAsync(sonarrEpisodeId.Value, seriesId, language).ConfigureAwait(false));
         }
 
         return BadRequest("Item must be a movie or episode");
@@ -209,17 +207,7 @@ public class BazarrController : ControllerBase
 
     private async Task<int?> ResolveRadarrIdAsync(Movie movie)
     {
-        // Try TMDB first - use ProviderIds dictionary directly
-        if (movie.ProviderIds.TryGetValue("Tmdb", out var tmdbIdStr) && int.TryParse(tmdbIdStr, out var tmdbId))
-        {
-            var radarrId = await _bazarrService.FindRadarrIdByTmdbAsync(tmdbId).ConfigureAwait(false);
-            if (radarrId != null)
-            {
-                return radarrId;
-            }
-        }
-
-        // Fallback to IMDB
+        // Bazarr's /api/movies response only exposes imdbId - there is no TMDB ID to match on
         if (movie.ProviderIds.TryGetValue("Imdb", out var imdbId) && !string.IsNullOrEmpty(imdbId))
         {
             return await _bazarrService.FindRadarrIdByImdbAsync(imdbId).ConfigureAwait(false);

--- a/Jellyfin.Plugin.Bazarr/Api/Models/BazarrMovie.cs
+++ b/Jellyfin.Plugin.Bazarr/Api/Models/BazarrMovie.cs
@@ -20,12 +20,6 @@ public class BazarrMovie
     public string Title { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the TMDB ID.
-    /// </summary>
-    [JsonPropertyName("tmdbId")]
-    public int? TmdbId { get; set; }
-
-    /// <summary>
     /// Gets or sets the IMDB ID.
     /// </summary>
     [JsonPropertyName("imdbId")]

--- a/Jellyfin.Plugin.Bazarr/Providers/BazarrSubtitleProvider.cs
+++ b/Jellyfin.Plugin.Bazarr/Providers/BazarrSubtitleProvider.cs
@@ -169,7 +169,9 @@ public class BazarrSubtitleProvider : ISubtitleProvider
         }
         catch (Exception ex)
         {
+            // Jellyfin swallows provider exceptions, so the user would otherwise just see "no results".
             _logger.LogError(ex, "Error searching Bazarr for subtitles");
+            return SubtitlePlaceholder.SearchFailed(ex.Message);
         }
 
         return Enumerable.Empty<RemoteSubtitleInfo>();
@@ -179,6 +181,11 @@ public class BazarrSubtitleProvider : ISubtitleProvider
     public async Task<SubtitleResponse> GetSubtitles(string id, CancellationToken cancellationToken)
     {
         _logger.LogInformation("Downloading subtitle from Bazarr: {Id}", id);
+
+        if (id.StartsWith(SubtitlePlaceholder.IdPrefix, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException("This entry is a status message, not a subtitle. Run the search again once Bazarr has results.");
+        }
 
         // ID format: "movie|episode|radarrId|sonarrEpisodeId|provider|hi|forced|subtitle(escaped)"
         var parts = id.Split('|');
@@ -259,11 +266,10 @@ public class BazarrSubtitleProvider : ISubtitleProvider
 
             if (itemType == "movie")
             {
-                // Find movie by Radarr ID via TMDB lookup
+                // Match on IMDB - Bazarr's /api/movies response carries no TMDB ID
                 var radarrMovie = await _bazarrService.GetMovieByRadarrIdAsync(bazarrId, cancellationToken).ConfigureAwait(false);
-                if (radarrMovie != null && radarrMovie.TmdbId.HasValue)
+                if (!string.IsNullOrEmpty(radarrMovie?.ImdbId))
                 {
-                    var tmdbIdStr = radarrMovie.TmdbId.Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
                     var movies = _libraryManager.GetItemList(new InternalItemsQuery
                     {
                         IncludeItemTypes = [BaseItemKind.Movie],
@@ -271,7 +277,8 @@ public class BazarrSubtitleProvider : ISubtitleProvider
                         Recursive = true
                     });
                     item = movies.FirstOrDefault(m =>
-                        m.ProviderIds.TryGetValue("Tmdb", out var id) && id == tmdbIdStr);
+                        m.ProviderIds.TryGetValue("Imdb", out var id) &&
+                        string.Equals(id, radarrMovie.ImdbId, StringComparison.OrdinalIgnoreCase));
                 }
             }
             else if (itemType == "episode")

--- a/Jellyfin.Plugin.Bazarr/Providers/EpisodeSubtitleHandler.cs
+++ b/Jellyfin.Plugin.Bazarr/Providers/EpisodeSubtitleHandler.cs
@@ -208,16 +208,7 @@ public class EpisodeSubtitleHandler
         if (searchResult.SearchInProgress)
         {
             _logger.LogInformation("Episode search in progress - returning placeholder to user");
-            return new[]
-            {
-                new RemoteSubtitleInfo
-                {
-                    Id = "search_in_progress",
-                    Name = "Search in progress - results typically ready in 5-15 minutes",
-                    ProviderName = "Bazarr",
-                    Comment = "Bazarr is searching multiple providers in the background. Click 'Search' again later to see cached results."
-                }
-            };
+            return SubtitlePlaceholder.SearchInProgress();
         }
 
         var subtitles = searchResult.Subtitles;

--- a/Jellyfin.Plugin.Bazarr/Providers/MovieSubtitleHandler.cs
+++ b/Jellyfin.Plugin.Bazarr/Providers/MovieSubtitleHandler.cs
@@ -48,23 +48,17 @@ public class MovieSubtitleHandler
         int timeoutSeconds,
         CancellationToken cancellationToken)
     {
-        // Try to find the movie in Bazarr by TMDB ID
+        // Bazarr's /api/movies response only exposes imdbId - there is no TMDB ID to match on
         int? radarrId = null;
 
-        if (providerIds.TryGetValue("Tmdb", out var tmdbIdStr) &&
-            int.TryParse(tmdbIdStr, out var tmdbId))
-        {
-            radarrId = await _bazarrService.FindRadarrIdByTmdbAsync(tmdbId, cancellationToken).ConfigureAwait(false);
-        }
-
-        if (radarrId == null && providerIds.TryGetValue("Imdb", out var imdbId))
+        if (providerIds.TryGetValue("Imdb", out var imdbId) && !string.IsNullOrEmpty(imdbId))
         {
             radarrId = await _bazarrService.FindRadarrIdByImdbAsync(imdbId, cancellationToken).ConfigureAwait(false);
         }
 
         if (radarrId == null)
         {
-            _logger.LogWarning("Movie not found in Bazarr: {Name}", name);
+            _logger.LogWarning("Movie not found in Bazarr (needs an IMDB ID in Jellyfin and Radarr): {Name}", name);
             return Enumerable.Empty<RemoteSubtitleInfo>();
         }
 
@@ -76,16 +70,7 @@ public class MovieSubtitleHandler
         if (searchResult.SearchInProgress)
         {
             _logger.LogInformation("Movie search in progress - returning placeholder to user");
-            return new[]
-            {
-                new RemoteSubtitleInfo
-                {
-                    Id = "search_in_progress",
-                    Name = "Search in progress - results typically ready in 5-15 minutes",
-                    ProviderName = "Bazarr",
-                    Comment = "Bazarr is searching multiple providers in the background. Click 'Search' again later to see cached results."
-                }
-            };
+            return SubtitlePlaceholder.SearchInProgress();
         }
 
         var subtitles = searchResult.Subtitles;

--- a/Jellyfin.Plugin.Bazarr/Providers/SubtitlePlaceholder.cs
+++ b/Jellyfin.Plugin.Bazarr/Providers/SubtitlePlaceholder.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using MediaBrowser.Model.Providers;
+
+namespace Jellyfin.Plugin.Bazarr.Providers;
+
+/// <summary>
+/// Builds the status rows shown in Jellyfin's subtitle list when there is no result to offer.
+/// These are not downloadable - <see cref="IdPrefix"/> identifies them.
+/// </summary>
+public static class SubtitlePlaceholder
+{
+    /// <summary>
+    /// Prefix marking a status row rather than a real subtitle.
+    /// </summary>
+    public const string IdPrefix = "placeholder_";
+
+    /// <summary>
+    /// Row shown while a Bazarr search continues in the background.
+    /// </summary>
+    /// <returns>A single-item result set.</returns>
+    public static IEnumerable<RemoteSubtitleInfo> SearchInProgress() => Create(
+        "in_progress",
+        "Search in progress - results typically ready in 5-15 minutes",
+        "Bazarr is searching multiple providers in the background. Click 'Search' again later to see cached results.");
+
+    /// <summary>
+    /// Row shown when a Bazarr search could not be completed.
+    /// </summary>
+    /// <param name="reason">The failure reason to show the user.</param>
+    /// <returns>A single-item result set.</returns>
+    public static IEnumerable<RemoteSubtitleInfo> SearchFailed(string reason) => Create(
+        "failed",
+        "Search failed",
+        reason);
+
+    private static IEnumerable<RemoteSubtitleInfo> Create(string id, string name, string comment) =>
+    [
+        new RemoteSubtitleInfo
+        {
+            Id = IdPrefix + id,
+            Name = name,
+            ProviderName = "Bazarr",
+            Comment = comment
+        }
+    ];
+}

--- a/Jellyfin.Plugin.Bazarr/Services/BazarrService.cs
+++ b/Jellyfin.Plugin.Bazarr/Services/BazarrService.cs
@@ -30,8 +30,8 @@ public class BazarrService : IBazarrService
     private readonly ILogger<BazarrService> _logger;
     private readonly IBazarrConfigProvider _configProvider;
 
-    // Track in-flight search requests to avoid duplicate Bazarr API calls
-    private readonly ConcurrentDictionary<string, Task<IReadOnlyList<SubtitleOption>>> _inFlightSearches = new();
+    // Track in-flight search requests to avoid duplicate Bazarr API calls, keyed by search cache key
+    private readonly ConcurrentDictionary<string, Lazy<Task<IReadOnlyList<SubtitleOption>>>> _inFlightSearches = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BazarrService"/> class.
@@ -117,24 +117,6 @@ public class BazarrService : IBazarrService
         _logger.LogInformation("Cached {Count} episodes for series {SeriesId}", episodes.Count, sonarrSeriesId);
 
         return episodes;
-    }
-
-    /// <inheritdoc />
-    public async Task<int?> FindRadarrIdByTmdbAsync(int tmdbId, CancellationToken cancellationToken = default)
-    {
-        var movies = await GetMoviesAsync(cancellationToken).ConfigureAwait(false);
-        var movie = movies.FirstOrDefault(m => m.TmdbId == tmdbId);
-
-        if (movie != null)
-        {
-            _logger.LogDebug("Found Radarr ID {RadarrId} for TMDB ID {TmdbId}", movie.RadarrId, tmdbId);
-        }
-        else
-        {
-            _logger.LogDebug("No movie found in Bazarr for TMDB ID {TmdbId}", tmdbId);
-        }
-
-        return movie?.RadarrId;
     }
 
     /// <inheritdoc />
@@ -334,82 +316,14 @@ public class BazarrService : IBazarrService
     }
 
     /// <inheritdoc />
-    public async Task<SubtitleSearchResult> SearchMovieSubtitlesAsync(int radarrId, string language, int timeoutSeconds = 0, CancellationToken cancellationToken = default)
-    {
-        var cacheKey = $"{MovieSearchCacheKeyPrefix}{radarrId}";
-
-        // Check if we have cached results
-        if (_cache.TryGetValue(cacheKey, out IReadOnlyList<SubtitleOption>? cached) && cached != null)
-        {
-            _logger.LogInformation("Returning cached subtitle search results for movie {RadarrId} ({Count} subtitles)", radarrId, cached.Count);
-            return new SubtitleSearchResult { Subtitles = cached, FromCache = true };
-        }
-
-        // Use GetOrAdd to atomically check if there's an in-flight search or create a new one
-        var searchKey = $"movie_{radarrId}";
-        var isNewSearch = false;
-
-        var searchTask = _inFlightSearches.GetOrAdd(searchKey, _ =>
-        {
-            isNewSearch = true;
-            // Use CancellationToken.None so the search continues even if the HTTP request is cancelled
-            return SearchMovieSubtitlesInternalAsync(radarrId, language, CancellationToken.None);
-        });
-
-        if (!isNewSearch)
-        {
-            _logger.LogInformation("Reusing in-flight search for movie {RadarrId}", radarrId);
-        }
-
-        try
-        {
-            // If timeout is enabled and this is a new search, use Task.WhenAny to return early
-            if (timeoutSeconds > 0 && isNewSearch)
-            {
-                var timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeoutSeconds), cancellationToken);
-                var completedTask = await Task.WhenAny(searchTask, timeoutTask).ConfigureAwait(false);
-
-                if (completedTask == timeoutTask)
-                {
-                    // Timeout reached - return placeholder, search continues in background
-                    _logger.LogInformation(
-                        "Search timeout ({Timeout}s) reached for movie {RadarrId}. Search continues in background.",
-                        timeoutSeconds,
-                        radarrId);
-
-                    // Continue search in background
-                    _ = ContinueSearchInBackgroundAsync(searchTask, cacheKey, searchKey, $"movie {radarrId}");
-
-                    return new SubtitleSearchResult
-                    {
-                        Subtitles = [],
-                        SearchInProgress = true
-                    };
-                }
-            }
-
-            var result = await searchTask.ConfigureAwait(false);
-
-            // Only cache if this was our search (avoid double-caching)
-            if (isNewSearch)
-            {
-                _cache.Set(cacheKey, result, SearchResultCacheDuration);
-                _inFlightSearches.TryRemove(searchKey, out _);
-            }
-
-            return new SubtitleSearchResult { Subtitles = result };
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error searching subtitles for movie {RadarrId}", radarrId);
-            if (isNewSearch)
-            {
-                _inFlightSearches.TryRemove(searchKey, out _);
-            }
-
-            throw;
-        }
-    }
+    public Task<SubtitleSearchResult> SearchMovieSubtitlesAsync(int radarrId, string language, int timeoutSeconds = 0, CancellationToken cancellationToken = default)
+        => SearchAsync(
+            $"{MovieSearchCacheKeyPrefix}{radarrId}",
+            $"movie {radarrId}",
+            // CancellationToken.None so the search survives the Jellyfin request being cancelled
+            () => SearchMovieSubtitlesInternalAsync(radarrId, language, CancellationToken.None),
+            timeoutSeconds,
+            cancellationToken);
 
     private async Task<IReadOnlyList<SubtitleOption>> SearchMovieSubtitlesInternalAsync(int radarrId, string language, CancellationToken cancellationToken)
     {
@@ -430,82 +344,14 @@ public class BazarrService : IBazarrService
     }
 
     /// <inheritdoc />
-    public async Task<SubtitleSearchResult> SearchEpisodeSubtitlesAsync(int sonarrEpisodeId, int sonarrSeriesId, string language, int timeoutSeconds = 0, CancellationToken cancellationToken = default)
-    {
-        var cacheKey = $"{EpisodeSearchCacheKeyPrefix}{sonarrEpisodeId}";
-
-        // Check if we have cached results
-        if (_cache.TryGetValue(cacheKey, out IReadOnlyList<SubtitleOption>? cached) && cached != null)
-        {
-            _logger.LogInformation("Returning cached subtitle search results for episode {EpisodeId} ({Count} subtitles)", sonarrEpisodeId, cached.Count);
-            return new SubtitleSearchResult { Subtitles = cached, FromCache = true };
-        }
-
-        // Use GetOrAdd to atomically check if there's an in-flight search or create a new one
-        var searchKey = $"episode_{sonarrEpisodeId}";
-        var isNewSearch = false;
-
-        var searchTask = _inFlightSearches.GetOrAdd(searchKey, _ =>
-        {
-            isNewSearch = true;
-            // Use CancellationToken.None so the search continues even if the HTTP request is cancelled
-            return SearchEpisodeSubtitlesInternalAsync(sonarrEpisodeId, language, CancellationToken.None);
-        });
-
-        if (!isNewSearch)
-        {
-            _logger.LogInformation("Reusing in-flight search for episode {EpisodeId}", sonarrEpisodeId);
-        }
-
-        try
-        {
-            // If timeout is enabled and this is a new search, use Task.WhenAny to return early
-            if (timeoutSeconds > 0 && isNewSearch)
-            {
-                var timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeoutSeconds), cancellationToken);
-                var completedTask = await Task.WhenAny(searchTask, timeoutTask).ConfigureAwait(false);
-
-                if (completedTask == timeoutTask)
-                {
-                    // Timeout reached - return placeholder, search continues in background
-                    _logger.LogInformation(
-                        "Search timeout ({Timeout}s) reached for episode {EpisodeId}. Search continues in background.",
-                        timeoutSeconds,
-                        sonarrEpisodeId);
-
-                    // Continue search in background
-                    _ = ContinueSearchInBackgroundAsync(searchTask, cacheKey, searchKey, $"episode {sonarrEpisodeId}");
-
-                    return new SubtitleSearchResult
-                    {
-                        Subtitles = [],
-                        SearchInProgress = true
-                    };
-                }
-            }
-
-            var result = await searchTask.ConfigureAwait(false);
-
-            // Only cache if this was our search (avoid double-caching)
-            if (isNewSearch)
-            {
-                _cache.Set(cacheKey, result, SearchResultCacheDuration);
-                _inFlightSearches.TryRemove(searchKey, out _);
-            }
-
-            return new SubtitleSearchResult { Subtitles = result };
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error searching subtitles for episode {EpisodeId}", sonarrEpisodeId);
-            if (isNewSearch)
-            {
-                _inFlightSearches.TryRemove(searchKey, out _);
-            }
-
-            throw;
-        }
-    }
+    public Task<SubtitleSearchResult> SearchEpisodeSubtitlesAsync(int sonarrEpisodeId, int sonarrSeriesId, string language, int timeoutSeconds = 0, CancellationToken cancellationToken = default)
+        => SearchAsync(
+            $"{EpisodeSearchCacheKeyPrefix}{sonarrEpisodeId}",
+            $"episode {sonarrEpisodeId}",
+            // CancellationToken.None so the search survives the Jellyfin request being cancelled
+            () => SearchEpisodeSubtitlesInternalAsync(sonarrEpisodeId, language, CancellationToken.None),
+            timeoutSeconds,
+            cancellationToken);
 
     private async Task<IReadOnlyList<SubtitleOption>> SearchEpisodeSubtitlesInternalAsync(int sonarrEpisodeId, string language, CancellationToken cancellationToken)
     {
@@ -526,31 +372,75 @@ public class BazarrService : IBazarrService
     }
 
     /// <summary>
-    /// Continues a search in the background after timeout, caching results when done.
+    /// Serves a subtitle search from cache, joins an identical in-flight search, or starts one.
+    /// Callers that hit <paramref name="timeoutSeconds"/> get an in-progress result while the
+    /// search keeps running - joining a search must never block longer than starting one.
     /// </summary>
-    private async Task ContinueSearchInBackgroundAsync(
-        Task<IReadOnlyList<SubtitleOption>> searchTask,
+    private async Task<SubtitleSearchResult> SearchAsync(
         string cacheKey,
-        string searchKey,
+        string itemDescription,
+        Func<Task<IReadOnlyList<SubtitleOption>>> search,
+        int timeoutSeconds,
+        CancellationToken cancellationToken)
+    {
+        if (_cache.TryGetValue(cacheKey, out IReadOnlyList<SubtitleOption>? cached) && cached != null)
+        {
+            _logger.LogInformation("Returning cached subtitle search results for {Item} ({Count} subtitles)", itemDescription, cached.Count);
+            return new SubtitleSearchResult { Subtitles = cached, FromCache = true };
+        }
+
+        // Lazy guarantees the Bazarr search starts exactly once even when callers race here.
+        var searchTask = _inFlightSearches.GetOrAdd(
+            cacheKey,
+            key => new Lazy<Task<IReadOnlyList<SubtitleOption>>>(() => RunSearchAsync(search, key, itemDescription))).Value;
+
+        if (timeoutSeconds > 0)
+        {
+            var timeoutTask = Task.Delay(TimeSpan.FromSeconds(timeoutSeconds), cancellationToken);
+            if (await Task.WhenAny(searchTask, timeoutTask).ConfigureAwait(false) != searchTask)
+            {
+                _logger.LogInformation(
+                    "Search timeout ({Timeout}s) reached for {Item}. Search continues in background.",
+                    timeoutSeconds,
+                    itemDescription);
+
+                return new SubtitleSearchResult { Subtitles = [], SearchInProgress = true };
+            }
+        }
+
+        return new SubtitleSearchResult { Subtitles = await searchTask.ConfigureAwait(false) };
+    }
+
+    /// <summary>
+    /// Owns a single in-flight search: caches the result and always releases the in-flight slot,
+    /// whether the caller is still waiting or has already timed out.
+    /// </summary>
+    private async Task<IReadOnlyList<SubtitleOption>> RunSearchAsync(
+        Func<Task<IReadOnlyList<SubtitleOption>>> search,
+        string cacheKey,
         string itemDescription)
     {
         try
         {
-            var result = await searchTask.ConfigureAwait(false);
+            var result = await search().ConfigureAwait(false);
             _cache.Set(cacheKey, result, SearchResultCacheDuration);
             _logger.LogInformation(
-                "Background search completed for {Item}. Found {Count} subtitles. Results cached for {Duration} minutes.",
+                "Search completed for {Item}. Found {Count} subtitles, cached for {Duration} minutes.",
                 itemDescription,
                 result.Count,
                 SearchResultCacheDuration.TotalMinutes);
+
+            return result;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Background search failed for {Item}", itemDescription);
+            // Failures are deliberately not cached so the next search retries.
+            _logger.LogError(ex, "Search failed for {Item}", itemDescription);
+            throw;
         }
         finally
         {
-            _inFlightSearches.TryRemove(searchKey, out _);
+            _inFlightSearches.TryRemove(cacheKey, out _);
         }
     }
 
@@ -770,6 +660,7 @@ public class BazarrService : IBazarrService
     /// <param name="response">The HTTP response to validate.</param>
     /// <param name="endpoint">The endpoint that was called (for logging).</param>
     /// <exception cref="InvalidOperationException">Thrown when response is invalid (HTML, redirect, etc).</exception>
+    /// <exception cref="HttpRequestException">Thrown when Bazarr returns an error status, carrying its own message.</exception>
     private async Task ValidateResponseAsync(HttpResponseMessage response, string endpoint)
     {
         // Check for redirect responses (301, 302, etc.)
@@ -818,7 +709,24 @@ public class BazarrService : IBazarrService
                 endpoint);
         }
 
-        // Now check for HTTP errors
-        response.EnsureSuccessStatusCode();
+        // Now check for HTTP errors. Bazarr explains the failure in a JSON-encoded string body
+        // (e.g. "All providers are throttled"), so surface that instead of a bare status code.
+        if (!response.IsSuccessStatusCode)
+        {
+            var body = (await response.Content.ReadAsStringAsync().ConfigureAwait(false)).Trim().Trim('"');
+            var detail = body.Length switch
+            {
+                0 => response.ReasonPhrase,
+                > 200 => body[..200],
+                _ => body
+            };
+
+            _logger.LogError("Bazarr returned {StatusCode} for {Endpoint}: {Detail}", (int)response.StatusCode, endpoint, detail);
+
+            throw new HttpRequestException(
+                $"Bazarr returned {(int)response.StatusCode} for {endpoint}: {detail}",
+                null,
+                response.StatusCode);
+        }
     }
 }

--- a/Jellyfin.Plugin.Bazarr/Services/IBazarrService.cs
+++ b/Jellyfin.Plugin.Bazarr/Services/IBazarrService.cs
@@ -33,15 +33,8 @@ public interface IBazarrService
     Task<IReadOnlyList<BazarrEpisode>> GetEpisodesAsync(int sonarrSeriesId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Finds the Radarr ID by TMDB ID.
-    /// </summary>
-    /// <param name="tmdbId">The TMDB ID.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The Radarr ID if found, null otherwise.</returns>
-    Task<int?> FindRadarrIdByTmdbAsync(int tmdbId, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Finds the Radarr ID by IMDB ID.
+    /// Bazarr's /api/movies response carries no TMDB ID, so IMDB is the only usable key.
     /// </summary>
     /// <param name="imdbId">The IMDB ID.</param>
     /// <param name="cancellationToken">Cancellation token.</param>

--- a/README.md
+++ b/README.md
@@ -141,8 +141,11 @@ dotnet build
 ### Testing
 
 ```bash
-dotnet test
+dotnet test                 # unit tests
+dev-env/e2e/run-e2e.sh      # Playwright tests against a real Jellyfin server
 ```
+
+See [dev-env/e2e/README.md](dev-env/e2e/README.md) for what the end-to-end suite provisions.
 
 ### Release Process
 
@@ -211,6 +214,10 @@ Don't worry - this is safe:
 ### Subtitle search shows "Search in progress"
 
 This is normal - Bazarr is querying multiple providers which takes time. Wait 5-15 minutes and click Search again to see cached results.
+
+### Subtitle search shows "Search failed"
+
+The row's comment carries Bazarr's own message. The most common one is `All providers are throttled`: a provider hit its rate or download limit - often right after a download - so Bazarr benched it for 1-3 hours. Check **Bazarr → System → Providers** for the retry time, or enable more providers.
 
 ### Downloaded subtitle doesn't appear
 

--- a/dev-env/e2e/Jellyfin.Plugin.Bazarr.E2E/FakeBazarr.cs
+++ b/dev-env/e2e/Jellyfin.Plugin.Bazarr.E2E/FakeBazarr.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using System.Text;
+
+namespace Jellyfin.Plugin.Bazarr.E2E;
+
+/// <summary>
+/// Stands in for Bazarr so error paths can be reproduced on demand.
+/// Replays Bazarr's exact wire format: flask-restx serialises <c>return 'msg', 500</c>
+/// as a JSON-encoded string with content type application/json
+/// (bazarr/api/providers/providers_movies.py, libs/flask_restx/representations.py).
+///
+/// Each scenario gets its own movie so the plugin's one-hour result cache cannot leak
+/// between tests.
+/// </summary>
+public sealed class FakeBazarr : IDisposable
+{
+    private readonly HttpListener _listener = new();
+
+    public FakeBazarr(int port = 16767)
+    {
+        Url = $"http://127.0.0.1:{port}/";
+        _listener.Prefixes.Add(Url);
+        _listener.Start();
+        _ = Task.Run(ServeAsync);
+    }
+
+    public string Url { get; }
+
+    public void Dispose()
+    {
+        _listener.Close();
+    }
+
+    // Bazarr's /api/movies model exposes imdbId and no TMDB ID at all.
+    private static (int Status, string Body) Respond(string path, string query) => (path, query) switch
+    {
+        ("/api/movies", _) => (200, """
+            {"data":[
+              {"radarrId":1,"title":"The Matrix","imdbId":"tt0133093","path":"/movies/The Matrix (1999)/matrix.mkv"},
+              {"radarrId":2,"title":"Inception","imdbId":"tt1375666","path":"/movies/Inception (2010)/inception.mkv"}
+            ],"total":2}
+            """),
+        ("/api/providers/movies", "radarrid=1") => (500, "\"All providers are throttled\"\n"),
+        ("/api/providers/movies", "radarrid=2") => (200, """
+            {"data":[{"provider":"opensubtitlescom","subtitle":"pickled","language":"en","score":98,
+              "release_info":["Inception.2010.1080p.BluRay.x264"],"matches":["hash"],
+              "original_format":"False","hearing_impaired":"False","forced":"False","uploader":"someone"}]}
+            """),
+        _ => (404, "\"unhandled\"\n")
+    };
+
+    private async Task ServeAsync()
+    {
+        while (_listener.IsListening)
+        {
+            HttpListenerContext ctx;
+            try
+            {
+                ctx = await _listener.GetContextAsync();
+            }
+            catch
+            {
+                return;
+            }
+
+            var url = ctx.Request.Url!;
+            var (status, body) = Respond(url.AbsolutePath, url.Query.TrimStart('?'));
+            var bytes = Encoding.UTF8.GetBytes(body);
+            ctx.Response.StatusCode = status;
+            ctx.Response.ContentType = "application/json";
+            ctx.Response.ContentLength64 = bytes.Length;
+            await ctx.Response.OutputStream.WriteAsync(bytes);
+            ctx.Response.Close();
+        }
+    }
+}

--- a/dev-env/e2e/Jellyfin.Plugin.Bazarr.E2E/Jellyfin.Plugin.Bazarr.E2E.csproj
+++ b/dev-env/e2e/Jellyfin.Plugin.Bazarr.E2E/Jellyfin.Plugin.Bazarr.E2E.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.56.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/dev-env/e2e/Jellyfin.Plugin.Bazarr.E2E/SubtitleSearchTests.cs
+++ b/dev-env/e2e/Jellyfin.Plugin.Bazarr.E2E/SubtitleSearchTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.Playwright;
+
+namespace Jellyfin.Plugin.Bazarr.E2E;
+
+/// <summary>
+/// Drives Jellyfin's real subtitle dialog in a browser against a real Jellyfin server
+/// running the plugin. Run dev-env/e2e/run-e2e.sh - it provisions the server first.
+/// </summary>
+public class SubtitleSearchTests : IAsyncLifetime
+{
+    private static readonly string JellyfinUrl = Env("JF_URL");
+
+    private FakeBazarr _bazarr = null!;
+    private IPlaywright _playwright = null!;
+    private IBrowser _browser = null!;
+
+    public async Task InitializeAsync()
+    {
+        _bazarr = new FakeBazarr();
+        _playwright = await Playwright.CreateAsync();
+        _browser = await _playwright.Chromium.LaunchAsync(new() { Args = ["--no-sandbox"] });
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _browser.CloseAsync();
+        _playwright.Dispose();
+        _bazarr.Dispose();
+    }
+
+    /// <summary>
+    /// Issue #9: Bazarr answers a throttled search with 500. Jellyfin's SubtitleManager
+    /// swallows provider exceptions, so before the fix the user saw "no results found"
+    /// and the reason only appeared in the server log.
+    /// </summary>
+    [Fact]
+    public async Task ThrottledBazarr_ShowsTheReasonInTheSubtitleDialog()
+    {
+        var page = await SearchSubtitlesAsync(Env("JF_ITEM_THROTTLED"));
+
+        var results = page.Locator(".subtitleResults");
+        await Assertions.Expect(results).ToContainTextAsync("Bazarr");
+        await Assertions.Expect(results).ToContainTextAsync("Search failed");
+        await Assertions.Expect(results).ToContainTextAsync("All providers are throttled");
+        await Assertions.Expect(page.Locator(".noSearchResults")).Not.ToBeVisibleAsync();
+
+        await page.ScreenshotAsync(new() { Path = "issue-9-throttled.png" });
+    }
+
+    /// <summary>
+    /// The status row must not displace real results when Bazarr answers normally.
+    /// </summary>
+    [Fact]
+    public async Task WorkingBazarr_ShowsTheSubtitle()
+    {
+        var page = await SearchSubtitlesAsync(Env("JF_ITEM_OK"));
+
+        var results = page.Locator(".subtitleResults");
+        await Assertions.Expect(results).ToContainTextAsync("Inception.2010.1080p.BluRay.x264");
+        await Assertions.Expect(results).ToContainTextAsync("opensubtitlescom");
+        await Assertions.Expect(results).Not.ToContainTextAsync("Search failed");
+    }
+
+    private static string Env(string name) =>
+        Environment.GetEnvironmentVariable(name)
+        ?? throw new InvalidOperationException($"{name} is not set - run dev-env/e2e/run-e2e.sh");
+
+    private async Task<IPage> SearchSubtitlesAsync(string itemId)
+    {
+        // An explicit locale is required: jellyfin-web calls toLocaleTimeString, which throws
+        // on the POSIX locale a bare container reports, and the details page never renders.
+        var context = await _browser.NewContextAsync(new()
+        {
+            ViewportSize = new() { Width = 1280, Height = 900 },
+            Locale = "en-US"
+        });
+        var page = await context.NewPageAsync();
+
+        var diagnostics = new List<string>();
+        page.Console += (_, m) => diagnostics.Add($"console.{m.Type}: {m.Text}");
+        page.PageError += (_, e) => diagnostics.Add($"pageerror: {e}");
+        page.Response += (_, r) => { if (r.Status >= 400) { diagnostics.Add($"http {r.Status}: {r.Url}"); } };
+
+        try
+        {
+            await page.GotoAsync($"{JellyfinUrl}/web/#/login.html");
+            await page.FillAsync("#txtManualName", Env("JF_USER"));
+            await page.FillAsync("#txtManualPassword", Env("JF_PASS"));
+            await page.Locator(".manualLoginForm button[type=submit]").ClickAsync();
+            await page.WaitForURLAsync(u => !u.Contains("login.html", StringComparison.Ordinal));
+
+            // Reload so the SPA boots straight into the details route rather than only
+            // changing the hash of the page it is already on.
+            await page.GotoAsync($"{JellyfinUrl}/web/#/details?id={itemId}");
+            await page.ReloadAsync();
+
+            await page.Locator("button.btnMoreCommands:not(.hide)").First.ClickAsync();
+            await page.Locator("button.actionSheetMenuItem[data-id=editsubtitles]").ClickAsync();
+            await page.Locator("#selectLanguage").WaitForAsync();
+
+            await page.SelectOptionAsync("#selectLanguage", "eng");
+            await page.Locator(".btnSearchSubtitles").ClickAsync();
+
+            // Bazarr searches are slow by design; the plugin's own timeout is 25s.
+            await page.Locator(".subtitleResults .listItem, .noSearchResults:visible")
+                .First.WaitForAsync(new() { Timeout = 60_000 });
+        }
+        catch
+        {
+            await page.ScreenshotAsync(new() { Path = "failure.png", FullPage = true });
+            await File.WriteAllTextAsync("failure.html", await page.ContentAsync());
+            await File.WriteAllLinesAsync("failure.log", diagnostics);
+            throw;
+        }
+
+        return page;
+    }
+}

--- a/dev-env/e2e/README.md
+++ b/dev-env/e2e/README.md
@@ -1,0 +1,43 @@
+# End-to-end tests
+
+Playwright tests that drive Jellyfin's real subtitle dialog in a browser, against a real
+Jellyfin server with the plugin installed.
+
+```bash
+./run-e2e.sh                    # provision + run
+SKIP_PROVISION=1 ./run-e2e.sh   # re-run against an already provisioned server
+```
+
+`provision.sh` downloads Jellyfin (10.11.11 by default, into `/opt/jf`), builds and installs
+the plugin, resets the server's data directory, runs the startup wizard, seeds two movies and
+points the plugin at Bazarr. `run-e2e.sh` then installs the Chromium build Playwright ships
+with and runs the tests.
+
+## What is faked, and why
+
+Bazarr itself is replaced by `FakeBazarr`, which replays Bazarr's exact wire format - a
+JSON-encoded string body with content type `application/json`, which is how flask-restx
+serialises `return 'All providers are throttled', 500` in
+`bazarr/api/providers/providers_movies.py`. Error paths like provider throttling cannot be
+triggered on demand in a real Bazarr, and that is precisely what these tests cover.
+
+Each scenario has its own movie, because the plugin caches search results for an hour:
+
+| Movie                          | Bazarr `radarrId` | Response                          |
+|--------------------------------|-------------------|-----------------------------------|
+| The Matrix (1999), tt0133093   | 1                 | 500 `All providers are throttled` |
+| Inception (2010), tt1375666    | 2                 | one English subtitle              |
+
+To run against a real Bazarr instead, set `BAZARR_URL` before provisioning.
+
+## Requirements
+
+`dotnet`, `curl`, `perl`, `ffmpeg`, and Chromium's shared libraries:
+
+```bash
+apt-get install -y ffmpeg libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libatspi2.0-0 \
+    libcups2 libxcomposite1 libxdamage1 libxkbcommon0 libpango-1.0-0 libcairo2
+```
+
+Failures write `failure.png`, `failure.html` and `failure.log` (browser console, page errors
+and any HTTP 4xx/5xx) next to the test binary.

--- a/dev-env/e2e/provision.sh
+++ b/dev-env/e2e/provision.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Provisions a real Jellyfin server with the Bazarr plugin installed, ready for the
+# Playwright end-to-end tests. Idempotent: re-running resets Jellyfin's data directory.
+set -euo pipefail
+
+JF_ROOT="${JF_ROOT:-/opt/jf}"
+JF_URL="${JF_URL:-http://127.0.0.1:8096}"
+JF_VERSION="${JF_VERSION:-10.11.11}"
+JF_USER=dev
+JF_PASS=dev123
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+log() { echo "[provision] $*"; }
+api() { curl -sS --max-time 60 -H "Authorization: MediaBrowser Token=\"$TOKEN\"" "$@"; }
+
+# --- 1. Jellyfin server + web UI -------------------------------------------------
+if [ ! -x "$JF_ROOT/jellyfin/jellyfin" ]; then
+    log "downloading Jellyfin $JF_VERSION"
+    mkdir -p "$JF_ROOT"
+    curl -sSL -o "$JF_ROOT/jellyfin.tar.gz" \
+        "https://repo.jellyfin.org/files/server/linux/latest-stable/amd64/jellyfin_${JF_VERSION}-amd64.tar.gz"
+    tar xzf "$JF_ROOT/jellyfin.tar.gz" -C "$JF_ROOT"
+    rm -f "$JF_ROOT/jellyfin.tar.gz"
+fi
+
+command -v ffmpeg >/dev/null || { log "ffmpeg is required (apt-get install ffmpeg)"; exit 1; }
+
+# --- 2. Media ---------------------------------------------------------------------
+# The IMDB ID in the folder name is what Bazarr matches on - Bazarr's /api/movies
+# response exposes imdbId and nothing else. One movie per scenario, so the plugin's
+# one-hour result cache cannot leak between tests.
+make_movie() {
+    local dir="$JF_ROOT/media/movies/$1" file="$2"
+    [ -f "$dir/$file" ] && return 0
+    mkdir -p "$dir"
+    ffmpeg -y -loglevel error -f lavfi -i testsrc=size=320x180:rate=5:duration=2 \
+        -c:v libx264 -preset ultrafast "$dir/$file"
+}
+log "creating test media"
+make_movie "The Matrix (1999) [imdbid-tt0133093]" "The.Matrix.1999.1080p.BluRay.x264.mkv"
+make_movie "Inception (2010) [imdbid-tt1375666]" "Inception.2010.1080p.BluRay.x264.mkv"
+
+# --- 3. Plugin --------------------------------------------------------------------
+log "building plugin"
+dotnet publish "$REPO_ROOT/Jellyfin.Plugin.Bazarr/Jellyfin.Plugin.Bazarr.csproj" \
+    -c Release -o "$JF_ROOT/plugin-build" --nologo -v q
+
+stop_jellyfin() {
+    for p in /proc/[0-9]*; do
+        case "$( { tr '\0' ' ' < "$p/cmdline"; } 2>/dev/null )" in
+            *"jellyfin --datadir $JF_ROOT/data"*) kill "${p#/proc/}" 2>/dev/null || true ;;
+        esac
+    done
+    for _ in $(seq 1 30); do
+        curl -s -o /dev/null --max-time 1 "$JF_URL/System/Info/Public" || return 0
+        sleep 1
+    done
+}
+stop_jellyfin
+rm -rf "$JF_ROOT/data" "$JF_ROOT/cache"
+mkdir -p "$JF_ROOT/data/plugins/Bazarr_1.0.0.0"
+cp "$JF_ROOT/plugin-build/Jellyfin.Plugin.Bazarr.dll" "$JF_ROOT/data/plugins/Bazarr_1.0.0.0/"
+
+# --- 4. Start ---------------------------------------------------------------------
+log "starting Jellyfin"
+(cd "$JF_ROOT/jellyfin" && nohup ./jellyfin \
+    --datadir "$JF_ROOT/data" --cachedir "$JF_ROOT/cache" \
+    --webdir "$JF_ROOT/jellyfin/jellyfin-web" --ffmpeg "$(command -v ffmpeg)" \
+    > "$JF_ROOT/jellyfin.log" 2>&1 &)
+
+# /System/Info/Public answers from the setup app while the server is still booting;
+# /Startup/User only returns 200 once the real host is up.
+for _ in $(seq 1 120); do
+    [ "$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$JF_URL/Startup/User" || true)" = "200" ] && break
+    sleep 1
+done
+grep -q "Loaded assembly Jellyfin.Plugin.Bazarr" "$JF_ROOT/jellyfin.log" || { log "plugin did not load"; exit 1; }
+
+# --- 5. Startup wizard ------------------------------------------------------------
+log "running startup wizard"
+curl -sS --max-time 30 -o /dev/null "$JF_URL/Startup/User"   # creates the default user
+curl -sS --max-time 30 -o /dev/null -X POST "$JF_URL/Startup/Configuration" -H 'Content-Type: application/json' \
+    -d '{"UICulture":"en-US","MetadataCountryCode":"US","PreferredMetadataLanguage":"en"}'
+curl -sS --max-time 30 -o /dev/null -X POST "$JF_URL/Startup/User" -H 'Content-Type: application/json' \
+    -d "{\"Name\":\"$JF_USER\",\"Password\":\"$JF_PASS\"}"
+curl -sS --max-time 30 -o /dev/null -X POST "$JF_URL/Startup/RemoteAccess" -H 'Content-Type: application/json' \
+    -d '{"EnableRemoteAccess":true,"EnableAutomaticPortMapping":false}'
+curl -sS --max-time 30 -o /dev/null -X POST "$JF_URL/Startup/Complete"
+
+TOKEN=$(curl -sS --max-time 30 -X POST "$JF_URL/Users/AuthenticateByName" -H 'Content-Type: application/json' \
+    -H 'Authorization: MediaBrowser Client="e2e", Device="cli", DeviceId="e2e-cli", Version="1.0"' \
+    -d "{\"Username\":\"$JF_USER\",\"Pw\":\"$JF_PASS\"}" | grep -oE '"AccessToken":"[^"]+"' | cut -d'"' -f4)
+[ -n "$TOKEN" ] || { log "authentication failed"; exit 1; }
+
+# --- 6. Library -------------------------------------------------------------------
+# Metadata fetchers are off: no outbound calls, IDs come from the folder name.
+log "adding movie library"
+api -o /dev/null -X POST "$JF_URL/Library/VirtualFolders?name=Movies&collectionType=movies&refreshLibrary=true" \
+    -H 'Content-Type: application/json' \
+    -d "{\"LibraryOptions\":{\"PathInfos\":[{\"Path\":\"$JF_ROOT/media/movies\"}],\"EnableInternetProviders\":false,\"MetadataCountryCode\":\"US\",\"PreferredMetadataLanguage\":\"en\",\"TypeOptions\":[{\"Type\":\"Movie\",\"MetadataFetchers\":[],\"ImageFetchers\":[]}]}}"
+
+api -o /dev/null -X POST "$JF_URL/Library/Refresh"
+# Jellyfin 10.11 ignores AnyProviderIdEquals on /Items, so match on the item name -
+# which is the folder name, IMDB tag included.
+find_item() {
+    local id=""
+    for _ in $(seq 1 180); do
+        id=$(api "$JF_URL/Items?IncludeItemTypes=Movie&Recursive=true" | IMDB="$1" perl -0ne '
+            while (/"Name":"([^"]*)","ServerId":"[^"]*","Id":"([0-9a-f]{32})"/g) {
+                print "$2\n" if index($1, $ENV{IMDB}) >= 0;
+            }' | head -1)
+        [ -n "$id" ] && { echo "$id"; return 0; }
+        sleep 1
+    done
+    log "movie $1 was not scanned in with its IMDB id"
+    return 1
+}
+ITEM_THROTTLED=$(find_item tt0133093)
+ITEM_OK=$(find_item tt1375666)
+
+# --- 7. Plugin configuration ------------------------------------------------------
+log "configuring Bazarr plugin -> ${BAZARR_URL:-http://127.0.0.1:16767}"
+api -o /dev/null -X POST "$JF_URL/Plugins/72449d0e-7ba4-4ae7-a996-c00e6b06c8f8/Configuration" \
+    -H 'Content-Type: application/json' \
+    -d "{\"BazarrUrl\":\"${BAZARR_URL:-http://127.0.0.1:16767}\",\"BazarrApiKey\":\"devkey123456789012345\",\"EnableForMovies\":true,\"EnableForEpisodes\":true,\"SearchTimeoutSeconds\":25}"
+
+cat > "$JF_ROOT/e2e.env" <<EOF
+JF_URL=$JF_URL
+JF_USER=$JF_USER
+JF_PASS=$JF_PASS
+JF_TOKEN=$TOKEN
+JF_ITEM_THROTTLED=$ITEM_THROTTLED
+JF_ITEM_OK=$ITEM_OK
+EOF
+
+log "ready - settings written to $JF_ROOT/e2e.env"

--- a/dev-env/e2e/run-e2e.sh
+++ b/dev-env/e2e/run-e2e.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Provisions Jellyfin + the plugin and runs the Playwright end-to-end tests.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+JF_ROOT="${JF_ROOT:-/opt/jf}"
+
+[ "${SKIP_PROVISION:-0}" = "1" ] || "$HERE/provision.sh"
+
+set -a
+# shellcheck source=/dev/null
+. "$JF_ROOT/e2e.env"
+set +a
+
+dotnet build "$HERE/Jellyfin.Plugin.Bazarr.E2E" --nologo -v q
+
+# Playwright ships its own Node, so no system Node is needed. Installs the browser once.
+# System libraries come from `apt-get install libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0
+# libatspi2.0-0 libcups2 libxcomposite1 libxdamage1 libxkbcommon0 libpango-1.0-0 libcairo2`.
+PW="$HERE/Jellyfin.Plugin.Bazarr.E2E/bin/Debug/net9.0/.playwright"
+"$PW"/node/*/node "$PW/package/cli.js" install chromium
+
+dotnet test "$HERE/Jellyfin.Plugin.Bazarr.E2E" --nologo "$@"


### PR DESCRIPTION
Fixes #9.

The 500 is Bazarr's and by design: downloading burns a provider's quota, Bazarr benches it for 1-3 hours, and `manual_search` then returns `'All providers are throttled'` with status 500. The plugin made that look like a plugin bug in two ways:

- `ValidateResponseAsync` discarded the response body, so the log showed only a bare 500.
- Jellyfin's `SubtitleManager` swallows provider exceptions, so the user just saw "no results found".

Bazarr's message is now surfaced as a status row in the subtitle dialog:

```
Bazarr
  Search failed
  Bazarr returned 500 for /api/providers/movies?radarrid=1: All providers are throttled
```

Also fixed while tracing this:

- **Post-download library refresh never ran for movies.** Bazarr's `/api/movies` has no `tmdbId` field, so `BazarrMovie.TmdbId` was always null and the refresh gated on it. Movies now match on `imdbId` throughout.
- **Joining an in-flight search ignored the timeout**, waiting up to the 20 minute HttpClient timeout. The two duplicated search methods are now one shared path (net -125 lines).
- **`/Bazarr/Search`** returned the result wrapper for movies but a bare list for episodes.

## Testing

`dotnet test` 41/41, plus Playwright tests in `dev-env/e2e/` that drive Jellyfin's real subtitle dialog against a real Jellyfin server with the plugin installed (Bazarr is faked, because throttling can't be triggered on demand). The throttled test fails on `main` with `But was: ''` - the silent empty list from the report.
