### PR TITLE
docs: correct ID matching claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ flowchart TB
 
 ```mermaid
 flowchart TB
-    A[User clicks Search] --> B[Plugin receives TMDB/TVDB ID]
+    A[User clicks Search] --> B[Plugin receives IMDB/TVDB ID]
     B --> C[Lookup Bazarr ID]
     C --> D[Search subtitles]
     D --> E{Results within 25s?}
@@ -227,7 +227,7 @@ The plugin triggers a library refresh after download. If it still doesn't appear
 
 ### Movie/Episode not found in Bazarr
 
-Ensure the item exists in Radarr/Sonarr and Bazarr has synced. The plugin matches by TMDB ID (movies) or TVDB ID (episodes).
+Ensure the item exists in Radarr/Sonarr and Bazarr has synced. The plugin matches movies by IMDB ID, and episodes by series TVDB/IMDB ID or title.
 
 ### Connection test fails with HTML/redirect errors
 


### PR DESCRIPTION
Two spots still said the plugin matches movies by TMDB ID. Since v1.2.0 it matches on IMDB - Bazarr's `/api/movies` returns no `tmdbId`. Episodes fall back through series TVDB/IMDB ID and title.

Both mermaid diagrams still parse and render (checked against mermaid 11.17.2).